### PR TITLE
Fix Timestamp format to be compatible with Grafana

### DIFF
--- a/src/sensu/sensu.ts
+++ b/src/sensu/sensu.ts
@@ -132,7 +132,7 @@ export default class Sensu {
    */
   static _handleRequestResult(result: any) {
     if (result) {
-      if (Array.isArray(result.data) && result.data.check) {
+      if (Array.isArray(result.data)) {
         result.data.forEach(o => {
           if (o.timestamp) {
             o.timestamp = o.timestamp * 1000;


### PR DESCRIPTION
Grafana expects Unix timestamps to include milliseconds, however the Sensu API returns the epoch time in seconds, so the values in Grafana show time around 1970s. This PR fixes it